### PR TITLE
Set plugin ordering when used with Vite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ export default function wbnOutputPlugin(opts) {
   }
   return {
     name: 'wbn-output-plugin',
+    enforce: 'post',
 
     async generateBundle(_, bundle) {
       const builder = new BundleBuilder(opts.formatVersion);


### PR DESCRIPTION
Vite adds an "enforce" option which allows plugins to configure whether they are executed before or after built-in Vite plugins.

In order for the Web Bundle to contain HTML assets generated by Vite's built-in HTML plugin this plugin needs to be configured to run "post".

Documentation: https://vitejs.dev/guide/api-plugin.html#plugin-ordering

Fixed #11.