### PR TITLE
Make empty baseURL be part of defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ should be written to `dist/signed.swbn`.
 
 ## Options
 
-### `baseURL` (required)
+### `baseURL`
 
-Type: `string`
+Type: `string`  
+Default: `''`
 
-Specifies the URL prefix prepended to the file names in the bundle. This must be
-an absolute URL that ends with `/`.
+Specifies the URL prefix prepended to the file names in the bundle. Non-empty
+baseURL must end with `/`.
 
 ### `formatVersion`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ import { IntegrityBlockSigner, WebBundleId, parsePemKey } from 'wbn-sign';
 
 const defaults = {
   output: 'out.wbn',
+  baseURL: '',
 };
 
 function addFile(builder, url, file) {
@@ -98,7 +99,7 @@ function validateOptions(opts) {
 }
 
 export default function wbnOutputPlugin(opts) {
-  opts = Object.assign({}, defaults, { baseURL: '' }, opts);
+  opts = Object.assign({}, defaults, opts);
   validateOptions(opts);
 
   return {


### PR DESCRIPTION
I assume there's no reason why this would not be part of the default values? :)