### PR TITLE
Move parsing the private key to be earlier to not duplicate efforts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ import * as wbnSign from 'wbn-sign';
 import dotenv from 'dotenv';
 dotenv.config({ path: './.env' });
 
+const key = wbnSign.parsePemKey(process.env.ED25519KEY);
+
 export default {
   input: 'src/index.js',
   output: {
@@ -78,14 +80,10 @@ export default {
   },
   plugins: [
     webbundle({
-      baseURL: new wbnSign.WebBundleId(
-        wbnSign.parsePemKey(process.env.ED25519KEY)
-      ).serializeWithIsolatedWebAppOrigin(),
+      baseURL: new wbnSign.WebBundleId(key).serializeWithIsolatedWebAppOrigin(),
       static: { dir: 'public' },
       output: 'signed.swbn',
-      integrityBlockSign: {
-        key: process.env.ED25519KEY,
-      },
+      integrityBlockSign: { key },
     }),
   ],
 };
@@ -136,20 +134,22 @@ Specifies the file name of the Web Bundle to emit.
 
 ### `integrityBlockSign`
 
-Type: `{ key: string }`
+Type: `{ key: KeyObject }`
 
 Object specifying the signing options with
 [Integrity Block](https://github.com/WICG/webpackage/blob/main/explainers/integrity-signature.md).
 
 ### `integrityBlockSign.key` (required if `integrityBlockSign` is in place)
 
-Type: `string`
+Type: `KeyObject`
 
-A PEM-encoded Ed25519 private key as a string, which can be generated with:
+A parsed Ed25519 private key, which can be generated with:
 
 ```bash
 openssl genpkey -algorithm Ed25519 -out ed25519key.pem
 ```
+
+And parsed with `wbnSign.parsePemKey(process.env.ED25519KEY)` helper function.
 
 Note than in order for it to be parsed correctly, it must contain the `BEGIN`
 and `END` texts and line breaks (`\n`). Below an example `.env` file:
@@ -171,6 +171,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) file.
 This is not an officially supported Google product.
 
 ## Release Notes
+
+### v0.1.0
+
+- BREAKING CHANGE: Change type of integrityBlockSign.key to be KeyObject instead of string.
+- Upgrade to support Rollup 3.
 
 ### v0.0.4
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import mime from 'mime';
 import * as path from 'path';
 import { BundleBuilder } from 'wbn';
-import { IntegrityBlockSigner, WebBundleId, parsePemKey } from 'wbn-sign';
+import { IntegrityBlockSigner, WebBundleId } from 'wbn-sign';
 
 const defaults = {
   output: 'out.wbn',
@@ -59,14 +59,13 @@ function maybeSignWebBundle(webBundle, opts) {
     return webBundle;
   }
 
-  const parsedPrivateKey = parsePemKey(opts.integrityBlockSign.key);
   const { signedWebBundle } = new IntegrityBlockSigner(webBundle, {
-    key: parsedPrivateKey,
+    key: opts.integrityBlockSign.key,
   }).sign();
 
   const consoleLogColor = { green: '\x1b[32m', reset: '\x1b[0m' };
   console.log(
-    `${consoleLogColor.green}${new WebBundleId(parsedPrivateKey)}${
+    `${consoleLogColor.green}${new WebBundleId(opts.integrityBlockSign.key)}${
       consoleLogColor.reset
     }\n`
   );
@@ -80,7 +79,7 @@ function validateIWAOptions(opts) {
 
   if (opts.baseURL !== '') {
     const expectedOrigin = new WebBundleId(
-      parsePemKey(opts.integrityBlockSign.key)
+      opts.integrityBlockSign.key
     ).serializeWithIsolatedWebAppOrigin();
 
     if (opts.baseURL !== expectedOrigin) {

--- a/test/test.js
+++ b/test/test.js
@@ -155,8 +155,9 @@ test('relative', async (t) => {
 });
 
 test('integrityBlockSign', async (t) => {
-  const testPrivateKey =
-    '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----';
+  const testPrivateKey = wbnSign.parsePemKey(
+    '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----'
+  );
   const fileName = 'out.wbn';
 
   const bundle = await rollup.rollup({
@@ -182,7 +183,7 @@ test('integrityBlockSign', async (t) => {
   t.truthy(wbnLength < swbnFile.length);
   const { signedWebBundle } = new wbnSign.IntegrityBlockSigner(
     swbnFile.slice(-wbnLength),
-    { key: wbnSign.parsePemKey(testPrivateKey) }
+    { key: testPrivateKey }
   ).sign();
 
   t.deepEqual(swbnFile, Buffer.from(signedWebBundle));


### PR DESCRIPTION
This is so that we don't have to parse the private key several times during signing process. This will become more important as otherwise we'd end up prompting the user for the passphrase many times or then we'd have to pass around the passphrase into more libraries.