### PR TITLE
Add validations for IWA headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ and `END` texts and line breaks (`\n`). Below an example `.env` file:
 ED25519KEY="-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----"
 ```
 
+### `integrityBlockSign.isIwa`
+
+Type: `boolean`
+
+If `undefined` or `true`, enforces certain
+[Isolated Web App](https://github.com/WICG/isolated-web-apps) -related checks
+for the headers. Also adds default IWA headers if completely missing. If set to
+`false`, skips validation checks and doesn't tamper with the headers.
+
 ### `headerOverride`
 
 Type: `{ [key: string]: string; }` |

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ import mime from 'mime';
 import * as path from 'path';
 import { BundleBuilder, combineHeadersForUrl } from 'wbn';
 import { IntegrityBlockSigner, WebBundleId } from 'wbn-sign';
-import iwaHeaders from './iwa-headers.js';
+import { iwaHeaderDefaults, checkAndAddIwaHeaders } from './iwa-headers.js';
 
 const defaults = {
   output: 'out.wbn',
@@ -51,8 +51,7 @@ function addAsset(
       pluginOptions.headerOverride,
       baseURL + relativeAssetPath
     );
-    if (shouldCheckIwaHeaders)
-      iwaHeaders.checkAndAddIwaHeaders(combinedIndexHeaders);
+    if (shouldCheckIwaHeaders) checkAndAddIwaHeaders(combinedIndexHeaders);
 
     builder.addExchange(
       baseURL + relativeAssetPath,
@@ -72,7 +71,7 @@ function addAsset(
     pluginOptions.headerOverride,
     baseURLWithAssetPath
   );
-  if (shouldCheckIwaHeaders) iwaHeaders.checkAndAddIwaHeaders(combinedHeaders);
+  if (shouldCheckIwaHeaders) checkAndAddIwaHeaders(combinedHeaders);
 
   builder.addExchange(
     baseURLWithAssetPath,
@@ -150,10 +149,10 @@ function maybeSetIwaDefaults(opts) {
   if (opts.headerOverride === undefined) {
     console.info(
       `Setting the empty headerOverrides to IWA defaults. To bundle a non-IWA, set \`integrityBlockSign { isIwa: false }\` in your plugin configs. Defaults are set to:\n ${JSON.stringify(
-        iwaHeaders.iwaHeaderDefaults
+        iwaHeaderDefaults
       )}`
     );
-    opts.headerOverride = iwaHeaders.iwaHeaderDefaults;
+    opts.headerOverride = iwaHeaderDefaults;
   }
 }
 
@@ -180,7 +179,7 @@ function validateIntegrityBlockOptions(opts) {
     opts.integrityBlockSign.isIwa === true &&
     typeof opts.headerOverride === 'object'
   ) {
-    iwaHeaders.checkAndAddIwaHeaders(opts.headerOverride);
+    checkAndAddIwaHeaders(opts.headerOverride);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,10 +138,8 @@ function maybeSignWebBundle(webBundle, opts) {
 }
 
 function maybeSetIwaDefaults(opts) {
-  if (
-    opts.integrityBlockSign.isIwa !== undefined &&
-    opts.integrityBlockSign.isIwa === false
-  ) {
+  // Note that `undefined` is ignored on purpose.
+  if (opts.integrityBlockSign.isIwa === false) {
     return;
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ import mime from 'mime';
 import * as path from 'path';
 import { BundleBuilder, combineHeadersForUrl } from 'wbn';
 import { IntegrityBlockSigner, WebBundleId } from 'wbn-sign';
+import iwaHeaders from './iwa-headers.js';
 
 const defaults = {
   output: 'out.wbn',
@@ -33,36 +34,50 @@ function addAsset(
   baseURL,
   relativeAssetPath, // Asset's path relative to app's base dir. E.g. sub-dir/helloworld.js
   assetContentBuffer,
-  overrideHeadersOption
+  pluginOptions
 ) {
   const parsedAssetPath = path.parse(relativeAssetPath);
-  const headers = {
-    'Content-Type':
-      mime.getType(relativeAssetPath) || 'application/octet-stream',
-  };
   const isIndexHtmlFile = parsedAssetPath.base === 'index.html';
 
+  // For object type, the IWA headers have already been check in constructor.
+  const shouldCheckIwaHeaders =
+    typeof pluginOptions.headerOverride === 'function' &&
+    pluginOptions.integrityBlockSign &&
+    pluginOptions.integrityBlockSign.isIwa;
+
   if (isIndexHtmlFile) {
+    const combinedIndexHeaders = combineHeadersForUrl(
+      { Location: './' },
+      pluginOptions.headerOverride,
+      baseURL + relativeAssetPath
+    );
+    if (shouldCheckIwaHeaders)
+      iwaHeaders.checkAndAddIwaHeaders(combinedIndexHeaders);
+
     builder.addExchange(
       baseURL + relativeAssetPath,
       301,
-      combineHeadersForUrl(
-        { Location: './' },
-        overrideHeadersOption,
-        baseURL + relativeAssetPath
-      ),
+      combinedIndexHeaders,
       '' // Empty content.
     );
   }
 
-  const baseURLWithAssetPath = isIndexHtmlFile
-    ? baseURL + parsedAssetPath.dir
-    : baseURL + relativeAssetPath;
+  const baseURLWithAssetPath =
+    baseURL + (isIndexHtmlFile ? parsedAssetPath.dir : relativeAssetPath);
+  const combinedHeaders = combineHeadersForUrl(
+    {
+      'Content-Type':
+        mime.getType(relativeAssetPath) || 'application/octet-stream',
+    },
+    pluginOptions.headerOverride,
+    baseURLWithAssetPath
+  );
+  if (shouldCheckIwaHeaders) iwaHeaders.checkAndAddIwaHeaders(combinedHeaders);
 
   builder.addExchange(
     baseURLWithAssetPath,
     200,
-    combineHeadersForUrl(headers, overrideHeadersOption, baseURLWithAssetPath),
+    combinedHeaders,
     assetContentBuffer
   );
 }
@@ -71,7 +86,7 @@ function addFilesRecursively(
   builder,
   baseURL,
   dir,
-  overrideHeadersOption,
+  pluginOptions,
   recPath = ''
 ) {
   if (baseURL !== '' && !baseURL.endsWith('/')) {
@@ -86,7 +101,7 @@ function addFilesRecursively(
         builder,
         baseURL,
         filePath,
-        overrideHeadersOption,
+        pluginOptions,
         recPath + fileName + '/'
       );
     } else {
@@ -98,7 +113,7 @@ function addFilesRecursively(
         baseURL,
         recPath + fileName,
         fileContent,
-        overrideHeadersOption
+        pluginOptions
       );
     }
   }
@@ -122,7 +137,31 @@ function maybeSignWebBundle(webBundle, opts) {
   return signedWebBundle;
 }
 
-function validateIWAOptions(opts) {
+function maybeSetIwaDefaults(opts) {
+  if (
+    opts.integrityBlockSign.isIwa !== undefined &&
+    opts.integrityBlockSign.isIwa === false
+  ) {
+    return;
+  }
+
+  // `isIwa` is defaulting to `true` if not provided as currently there is no
+  // other use case for integrityBlockSign outside of IWAs.
+  opts.integrityBlockSign.isIwa = true;
+
+  if (opts.headerOverride === undefined) {
+    console.info(
+      `Setting the empty headerOverrides to IWA defaults. To bundle a non-IWA, set \`integrityBlockSign { isIwa: false }\` in your plugin configs. Defaults are set to:\n ${JSON.stringify(
+        iwaHeaders.iwaHeaderDefaults
+      )}`
+    );
+    opts.headerOverride = iwaHeaders.iwaHeaderDefaults;
+  }
+}
+
+function validateIntegrityBlockOptions(opts) {
+  maybeSetIwaDefaults(opts);
+
   if (opts.primaryURL !== undefined) {
     throw new Error('Primary URL is not supported for Isolated Web Apps.');
   }
@@ -138,13 +177,22 @@ function validateIWAOptions(opts) {
       );
     }
   }
+
+  if (
+    opts.integrityBlockSign.isIwa === true &&
+    typeof opts.headerOverride === 'object'
+  ) {
+    iwaHeaders.checkAndAddIwaHeaders(opts.headerOverride);
+  }
 }
 
 function validateOptions(opts) {
   if (opts.baseURL !== '' && !opts.baseURL.endsWith('/')) {
     throw new Error('Non-empty baseURL must end with "/".');
   }
-  if (opts.integrityBlockSign) validateIWAOptions(opts);
+  if (opts.integrityBlockSign) {
+    validateIntegrityBlockOptions(opts);
+  }
 }
 
 export default function wbnOutputPlugin(opts) {
@@ -165,7 +213,7 @@ export default function wbnOutputPlugin(opts) {
           builder,
           opts.static.baseURL || opts.baseURL,
           opts.static.dir,
-          opts.headerOverride
+          opts
         );
       }
 
@@ -177,7 +225,7 @@ export default function wbnOutputPlugin(opts) {
           opts.baseURL,
           asset.fileName, // This contains the relative path to the base dir already.
           content,
-          opts.headerOverride
+          opts
         );
         delete bundle[name];
       }

--- a/lib/iwa-headers.js
+++ b/lib/iwa-headers.js
@@ -1,23 +1,33 @@
-const coep = Object.freeze({ 'cross-origin-embedder-policy': 'require-corp' });
-const coop = Object.freeze({ 'cross-origin-opener-policy': 'same-origin' });
-const corp = Object.freeze({ 'cross-origin-resource-policy': 'same-origin' });
+export const coep = Object.freeze({
+  'cross-origin-embedder-policy': 'require-corp',
+});
+export const coop = Object.freeze({
+  'cross-origin-opener-policy': 'same-origin',
+});
+export const corp = Object.freeze({
+  'cross-origin-resource-policy': 'same-origin',
+});
 
-const CSP_HEADER_NAME = 'content-security-policy';
-const csp = Object.freeze({
+export const CSP_HEADER_NAME = 'content-security-policy';
+export const csp = Object.freeze({
   [CSP_HEADER_NAME]:
     "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https:; connect-src 'self' https:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script'; frame-ancestors 'self';",
 });
 
 // These headers must have these exact values for Isolated Web Apps, whereas the
 // CSP header can also be more strict.
-const invariableIwaHeaders = Object.freeze({ ...coep, ...coop, ...corp });
+export const invariableIwaHeaders = Object.freeze({
+  ...coep,
+  ...coop,
+  ...corp,
+});
 
-const iwaHeaderDefaults = Object.freeze({
+export const iwaHeaderDefaults = Object.freeze({
   ...csp,
   ...invariableIwaHeaders,
 });
 
-function headerNamesToLowerCase(headers) {
+export function headerNamesToLowerCase(headers) {
   const lowerCaseHeaders = {};
   for (const [headerName, headerValue] of Object.entries(headers)) {
     lowerCaseHeaders[headerName.toLowerCase()] = headerValue;
@@ -29,7 +39,7 @@ const ifNotIwaMsg =
   "If you are bundling a non-IWA, set `integrityBlockSign: { isIwa: false }` in the plugin's configuration.";
 
 // Checks if the IWA headers are strict enough or adds in case missing.
-function checkAndAddIwaHeaders(headers) {
+export function checkAndAddIwaHeaders(headers) {
   const lowerCaseHeaders = headerNamesToLowerCase(headers);
 
   // Add missing IWA headers.
@@ -60,15 +70,3 @@ function checkAndAddIwaHeaders(headers) {
 
   // TODO: Parse and check strictness of `Content-Security-Policy`.
 }
-
-export default {
-  coep,
-  coop,
-  corp,
-  CSP_HEADER_NAME,
-  csp,
-  invariableIwaHeaders,
-  iwaHeaderDefaults,
-  headerNamesToLowerCase,
-  checkAndAddIwaHeaders,
-};

--- a/lib/iwa-headers.js
+++ b/lib/iwa-headers.js
@@ -1,0 +1,74 @@
+const coep = Object.freeze({ 'cross-origin-embedder-policy': 'require-corp' });
+const coop = Object.freeze({ 'cross-origin-opener-policy': 'same-origin' });
+const corp = Object.freeze({ 'cross-origin-resource-policy': 'same-origin' });
+
+const CSP_HEADER_NAME = 'content-security-policy';
+const csp = Object.freeze({
+  [CSP_HEADER_NAME]:
+    "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https:; connect-src 'self' https:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script'; frame-ancestors 'self';",
+});
+
+// These headers must have these exact values for Isolated Web Apps, whereas the
+// CSP header can also be more strict.
+const invariableIwaHeaders = Object.freeze({ ...coep, ...coop, ...corp });
+
+const iwaHeaderDefaults = Object.freeze({
+  ...csp,
+  ...invariableIwaHeaders,
+});
+
+function headerNamesToLowerCase(headers) {
+  const lowerCaseHeaders = {};
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    lowerCaseHeaders[headerName.toLowerCase()] = headerValue;
+  }
+  return lowerCaseHeaders;
+}
+
+const ifNotIwaMsg =
+  "If you are bundling a non-IWA, set `integrityBlockSign: { isIwa: false }` in the plugin's configuration.";
+
+// Checks if the IWA headers are strict enough or adds in case missing.
+function checkAndAddIwaHeaders(headers) {
+  const lowerCaseHeaders = headerNamesToLowerCase(headers);
+
+  // Add missing IWA headers.
+  for (const [iwaHeaderName, iwaHeaderValue] of Object.entries(
+    iwaHeaderDefaults
+  )) {
+    if (!lowerCaseHeaders[iwaHeaderName]) {
+      console.log(
+        `For Isolated Web Apps, ${iwaHeaderName} header was automatically set to ${iwaHeaderValue}. ${ifNotIwaMsg}`
+      );
+      headers[iwaHeaderName] = iwaHeaderValue;
+    }
+  }
+
+  // Check strictness of IWA headers (apart from special case `Content-Security-Policy`).
+  for (const [iwaHeaderName, iwaHeaderValue] of Object.entries(
+    invariableIwaHeaders
+  )) {
+    if (
+      lowerCaseHeaders[iwaHeaderName] &&
+      lowerCaseHeaders[iwaHeaderName].toLowerCase() !== iwaHeaderValue
+    ) {
+      throw new Error(
+        `For Isolated Web Apps ${iwaHeaderName} should be ${iwaHeaderValue}. Now it is ${headers[iwaHeaderName]}. ${ifNotIwaMsg}`
+      );
+    }
+  }
+
+  // TODO: Parse and check strictness of `Content-Security-Policy`.
+}
+
+export default {
+  coep,
+  coop,
+  corp,
+  CSP_HEADER_NAME,
+  csp,
+  invariableIwaHeaders,
+  iwaHeaderDefaults,
+  headerNamesToLowerCase,
+  checkAndAddIwaHeaders,
+};

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,13 @@ import * as wbn from 'wbn';
 import * as wbnSign from 'wbn-sign';
 
 import webbundle from '../lib/index.js';
+import iwaHeaders from '../lib/iwa-headers.js';
+
+const TEST_ED25519_PRIVATE_KEY = wbnSign.parsePemKey(
+  '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----'
+);
+const TEST_IWA_BASE_URL =
+  'isolated-app://4tkrnsmftl4ggvvdkfth3piainqragus2qbhf7rlz2a3wo3rh4wqaaic/';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 process.chdir(__dirname);
@@ -155,20 +162,16 @@ test('relative', async (t) => {
 });
 
 test('integrityBlockSign', async (t) => {
-  const testPrivateKey = wbnSign.parsePemKey(
-    '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----'
-  );
-  const fileName = 'out.wbn';
+  const outputFileName = 'out.swbn';
 
   const bundle = await rollup.rollup({
     input: 'fixtures/index.js',
     plugins: [
       webbundle({
-        baseURL:
-          'isolated-app://4tkrnsmftl4ggvvdkfth3piainqragus2qbhf7rlz2a3wo3rh4wqaaic/',
-        output: fileName,
+        baseURL: TEST_IWA_BASE_URL,
+        output: outputFileName,
         integrityBlockSign: {
-          key: testPrivateKey,
+          key: TEST_ED25519_PRIVATE_KEY,
         },
       }),
     ],
@@ -176,15 +179,213 @@ test('integrityBlockSign', async (t) => {
   const { output } = await bundle.generate({ format: 'esm' });
   const keys = Object.keys(output);
   t.is(keys.length, 1);
-  t.is(output[keys[0]].fileName, fileName);
+  t.is(output[keys[0]].fileName, outputFileName);
 
   const swbnFile = output[keys[0]].source;
   const wbnLength = Number(Buffer.from(swbnFile.slice(-8)).readBigUint64BE());
   t.truthy(wbnLength < swbnFile.length);
   const { signedWebBundle } = new wbnSign.IntegrityBlockSigner(
     swbnFile.slice(-wbnLength),
-    { key: testPrivateKey }
+    { key: TEST_ED25519_PRIVATE_KEY }
   ).sign();
 
   t.deepEqual(swbnFile, Buffer.from(signedWebBundle));
+});
+
+test('headerOverride - IWA with good headers', async (t) => {
+  const headersTestCases = [
+    // These are added manually as they expect more than just `iwaHeaderDefaults`.
+    {
+      headerOverride: {
+        ...iwaHeaders.iwaHeaderDefaults,
+        'X-Csrf-Token': 'hello-world',
+      },
+      expectedHeaders: {
+        ...iwaHeaders.iwaHeaderDefaults,
+        'x-csrf-token': 'hello-world',
+      },
+    },
+    {
+      headerOverride: () => {
+        return {
+          ...iwaHeaders.iwaHeaderDefaults,
+          'X-Csrf-Token': 'hello-world',
+        };
+      },
+      expectedHeaders: {
+        ...iwaHeaders.iwaHeaderDefaults,
+        'x-csrf-token': 'hello-world',
+      },
+    },
+  ];
+
+  const headersThatDefaultToIWADefaults = [
+    { ...iwaHeaders.coop, ...iwaHeaders.corp, ...iwaHeaders.csp },
+    { ...iwaHeaders.coep, ...iwaHeaders.corp, ...iwaHeaders.csp },
+    { ...iwaHeaders.coep, ...iwaHeaders.coop, ...iwaHeaders.csp },
+    { ...iwaHeaders.coep, ...iwaHeaders.coop, ...iwaHeaders.corp },
+    iwaHeaders.iwaHeaderDefaults,
+    {},
+    undefined,
+    {
+      ...iwaHeaders.iwaHeaderDefaults,
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  ];
+
+  for (const headers of headersThatDefaultToIWADefaults) {
+    // Both functions and objects are ok so let's test with both.
+    headersTestCases.push({
+      headerOverride: headers,
+      expectedHeaders: iwaHeaders.iwaHeaderDefaults,
+    });
+
+    // Not supported as typeof function because that's forced to return `Headers` map.
+    if (headers === undefined) continue;
+    headersTestCases.push({
+      headerOverride: () => headers,
+      expectedHeaders: iwaHeaders.iwaHeaderDefaults,
+    });
+  }
+
+  const outputFileName = 'out.swbn';
+  for (const headersTestCase of headersTestCases) {
+    for (const isIwaTestCase of [undefined, true]) {
+      const bundle = await rollup.rollup({
+        input: 'fixtures/index.js',
+        plugins: [
+          webbundle({
+            baseURL: TEST_IWA_BASE_URL,
+            output: outputFileName,
+            integrityBlockSign: {
+              key: TEST_ED25519_PRIVATE_KEY,
+              isIwa: isIwaTestCase,
+            },
+            headerOverride: headersTestCase.headerOverride,
+          }),
+        ],
+      });
+      const { output } = await bundle.generate({ format: 'esm' });
+      const keys = Object.keys(output);
+      t.is(keys.length, 1);
+      t.is(output[keys[0]].fileName, outputFileName);
+
+      const swbnFile = output[keys[0]].source;
+      const wbnLength = Number(
+        Buffer.from(swbnFile.slice(-8)).readBigUint64BE()
+      );
+      t.truthy(wbnLength < swbnFile.length);
+
+      const usignedBundle = new wbn.Bundle(swbnFile.slice(-wbnLength));
+      for (const url of usignedBundle.urls) {
+        for (const [headerName, headerValue] of Object.entries(
+          iwaHeaders.iwaHeaderDefaults
+        )) {
+          t.is(usignedBundle.getResponse(url).headers[headerName], headerValue);
+        }
+      }
+    }
+  }
+});
+
+test('headerOverride - IWA with bad headers', async (t) => {
+  const badHeadersTestCase = [
+    { 'cross-origin-embedder-policy': 'unsafe-none' },
+    { 'cross-origin-opener-policy': 'unsafe-none' },
+    { 'cross-origin-resource-policy': 'cross-origin' },
+  ];
+
+  for (const badHeaders of badHeadersTestCase) {
+    for (const isIwaTestCase of [undefined, true]) {
+      await t.throwsAsync(
+        async () => {
+          await rollup.rollup({
+            input: 'fixtures/index.js',
+            plugins: [
+              webbundle({
+                baseURL: TEST_IWA_BASE_URL,
+                output: 'example.swbn',
+                integrityBlockSign: {
+                  key: TEST_ED25519_PRIVATE_KEY,
+                  isIwa: isIwaTestCase,
+                },
+                headerOverride: badHeaders,
+              }),
+            ],
+          });
+        },
+        { instanceOf: Error }
+      );
+    }
+  }
+});
+
+test("headerOverride - non-IWA doesn't enforce IWA headers", async (t) => {
+  // Irrelevant what this would contain.
+  const randomNonIwaHeaders = { 'x-csrf-token': 'hello-world' };
+
+  const headersTestCases = [
+    {
+      // Type `object` is ok.
+      headerOverride: randomNonIwaHeaders,
+      expectedHeaders: randomNonIwaHeaders,
+    },
+    {
+      // Same but camel case, which gets lower-cased.
+      headerOverride: { 'X-Csrf-Token': 'hello-world' },
+      expectedHeaders: randomNonIwaHeaders,
+    },
+    {
+      // Type `function` is ok.
+      headerOverride: () => randomNonIwaHeaders,
+      expectedHeaders: randomNonIwaHeaders,
+    },
+    {
+      // When `integrityBlockSign.isIwa` is false and `headerOverride` is
+      // `undefined`, nothing unusual gets added.
+      headerOverride: undefined,
+      expectedHeaders: {},
+    },
+  ];
+
+  const outputFileName = 'out.swbn';
+  for (const headersTestCase of headersTestCases) {
+    const bundle = await rollup.rollup({
+      input: 'fixtures/index.js',
+      plugins: [
+        webbundle({
+          baseURL: TEST_IWA_BASE_URL,
+          output: outputFileName,
+          integrityBlockSign: {
+            key: TEST_ED25519_PRIVATE_KEY,
+            isIwa: false,
+          },
+          headerOverride: headersTestCase.headerOverride,
+        }),
+      ],
+    });
+
+    const { output } = await bundle.generate({ format: 'esm' });
+    const keys = Object.keys(output);
+    t.is(keys.length, 1);
+    t.is(output[keys[0]].fileName, outputFileName);
+    const swbnFile = output[keys[0]].source;
+
+    const wbnLength = Number(Buffer.from(swbnFile.slice(-8)).readBigUint64BE());
+    t.truthy(wbnLength < swbnFile.length);
+
+    const usignedBundle = new wbn.Bundle(swbnFile.slice(-wbnLength));
+    for (const url of usignedBundle.urls) {
+      // Added the expected headers.
+      for (const [headerName, headerValue] of Object.entries(
+        headersTestCase.expectedHeaders
+      )) {
+        t.is(usignedBundle.getResponse(url).headers[headerName], headerValue);
+      }
+      // Did not add any IWA headers automatically.
+      for (const headerName of Object.keys(iwaHeaders.iwaHeaderDefaults)) {
+        t.is(usignedBundle.getResponse(url).headers[headerName], undefined);
+      }
+    }
+  }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,13 @@ import * as wbn from 'wbn';
 import * as wbnSign from 'wbn-sign';
 
 import webbundle from '../lib/index.js';
-import iwaHeaders from '../lib/iwa-headers.js';
+import {
+  coep,
+  coop,
+  corp,
+  csp,
+  iwaHeaderDefaults,
+} from '../lib/iwa-headers.js';
 
 const TEST_ED25519_PRIVATE_KEY = wbnSign.parsePemKey(
   '-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIB8nP5PpWU7HiILHSfh5PYzb5GAcIfHZ+bw6tcd/LZXh\n-----END PRIVATE KEY-----'
@@ -197,38 +203,38 @@ test('headerOverride - IWA with good headers', async (t) => {
     // These are added manually as they expect more than just `iwaHeaderDefaults`.
     {
       headerOverride: {
-        ...iwaHeaders.iwaHeaderDefaults,
+        ...iwaHeaderDefaults,
         'X-Csrf-Token': 'hello-world',
       },
       expectedHeaders: {
-        ...iwaHeaders.iwaHeaderDefaults,
+        ...iwaHeaderDefaults,
         'x-csrf-token': 'hello-world',
       },
     },
     {
       headerOverride: () => {
         return {
-          ...iwaHeaders.iwaHeaderDefaults,
+          ...iwaHeaderDefaults,
           'X-Csrf-Token': 'hello-world',
         };
       },
       expectedHeaders: {
-        ...iwaHeaders.iwaHeaderDefaults,
+        ...iwaHeaderDefaults,
         'x-csrf-token': 'hello-world',
       },
     },
   ];
 
   const headersThatDefaultToIWADefaults = [
-    { ...iwaHeaders.coop, ...iwaHeaders.corp, ...iwaHeaders.csp },
-    { ...iwaHeaders.coep, ...iwaHeaders.corp, ...iwaHeaders.csp },
-    { ...iwaHeaders.coep, ...iwaHeaders.coop, ...iwaHeaders.csp },
-    { ...iwaHeaders.coep, ...iwaHeaders.coop, ...iwaHeaders.corp },
-    iwaHeaders.iwaHeaderDefaults,
+    { ...coop, ...corp, ...csp },
+    { ...coep, ...corp, ...csp },
+    { ...coep, ...coop, ...csp },
+    { ...coep, ...coop, ...corp },
+    iwaHeaderDefaults,
     {},
     undefined,
     {
-      ...iwaHeaders.iwaHeaderDefaults,
+      ...iwaHeaderDefaults,
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
   ];
@@ -237,14 +243,14 @@ test('headerOverride - IWA with good headers', async (t) => {
     // Both functions and objects are ok so let's test with both.
     headersTestCases.push({
       headerOverride: headers,
-      expectedHeaders: iwaHeaders.iwaHeaderDefaults,
+      expectedHeaders: iwaHeaderDefaults,
     });
 
     // Not supported as typeof function because that's forced to return `Headers` map.
     if (headers === undefined) continue;
     headersTestCases.push({
       headerOverride: () => headers,
-      expectedHeaders: iwaHeaders.iwaHeaderDefaults,
+      expectedHeaders: iwaHeaderDefaults,
     });
   }
 
@@ -279,7 +285,7 @@ test('headerOverride - IWA with good headers', async (t) => {
       const usignedBundle = new wbn.Bundle(swbnFile.slice(-wbnLength));
       for (const url of usignedBundle.urls) {
         for (const [headerName, headerValue] of Object.entries(
-          iwaHeaders.iwaHeaderDefaults
+          iwaHeaderDefaults
         )) {
           t.is(usignedBundle.getResponse(url).headers[headerName], headerValue);
         }
@@ -383,7 +389,7 @@ test("headerOverride - non-IWA doesn't enforce IWA headers", async (t) => {
         t.is(usignedBundle.getResponse(url).headers[headerName], headerValue);
       }
       // Did not add any IWA headers automatically.
-      for (const headerName of Object.keys(iwaHeaders.iwaHeaderDefaults)) {
+      for (const headerName of Object.keys(iwaHeaderDefaults)) {
         t.is(usignedBundle.getResponse(url).headers[headerName], undefined);
       }
     }


### PR DESCRIPTION
Pretty much same as the previous PR to the webpack plugin.

However the Rollup plugin seems to only support modules (`export default`) and not CommonJS (`module.exports`). This is enforced in `package.json` with `"type": "module"`.

I asked Kunihiko and the main reason was that it's more common to use ES modules for Rollup plugins. However I did find other plugins written in CommonJS. I also tested refactoring this library into a CommonJS one [here](https://github.com/GoogleChromeLabs/rollup-plugin-webbundle/compare/master...sonkkeli:rollup-plugin-webbundle:dont-enforce-modules?expand=1) (see 2nd commit) 